### PR TITLE
Makes maven fail on error during integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ dependencies:
 
 test:
   override:
-    - ./mvnw integration-test
+    - ./mvnw verify
   post:
     # parameters used during release
     # allocate commits to CI, not the owner of the deploy key


### PR DESCRIPTION
Exceptions are not assertions, so materialize as errors. Errors don't
cause the integration-test phase to fail, while it will for verify.