### PR TITLE
Disables outbound client propagation by default

### DIFF
--- a/cassandra-driver/src/main/java/brave/cassandra/driver/CassandraClientTracing.java
+++ b/cassandra-driver/src/main/java/brave/cassandra/driver/CassandraClientTracing.java
@@ -27,7 +27,8 @@ public abstract class CassandraClientTracing {
     return new AutoValue_CassandraClientTracing.Builder()
         .tracing(tracing)
         .parser(new CassandraClientParser())
-        .sampler(CassandraClientSampler.TRACE_ID);
+        .sampler(CassandraClientSampler.TRACE_ID)
+        .propagationEnabled(false);
   }
 
   public abstract Tracing tracing();
@@ -62,6 +63,15 @@ public abstract class CassandraClientTracing {
   }
 
   /**
+   * When true, trace contexts will be propagated downstream based on the {@link
+   * Tracing#propagationFactory() configured implementation}.
+   *
+   * <p>Warning: sometimes this can cause connection failures. As such, consider this feature
+   * experimental.
+   */
+  public abstract boolean propagationEnabled();
+
+  /**
    * Returns an overriding sampling decision for a new trace. Defaults to ignore the request and use
    * the {@link CassandraClientSampler#TRACE_ID trace ID instead}.
    */
@@ -79,6 +89,9 @@ public abstract class CassandraClientTracing {
 
     /** @see CassandraClientTracing#sampler() */
     public abstract Builder sampler(CassandraClientSampler sampler);
+
+    /** @see CassandraClientTracing#propagationEnabled() */
+    public abstract Builder propagationEnabled(boolean propagationEnabled);
 
     public abstract CassandraClientTracing build();
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-sender-urlconnection</artifactId>
-      <version>${zipkin-reporter.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,7 @@
     <main.signature.artifact>java17</main.signature.artifact>
 
     <main.basedir>${project.basedir}</main.basedir>
-    <brave.version>5.0.0</brave.version>
-    <zipkin-reporter.version>2.6.1</zipkin-reporter.version>
+    <brave.version>5.1.0</brave.version>
 
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
@@ -97,6 +96,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave-bom</artifactId>
+        <version>${brave.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-all</artifactId>
         <version>3.11.2</version>
@@ -133,7 +139,6 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
-      <version>${brave.version}</version>
     </dependency>
 
     <!-- don't worry. auto-* are source retention, not runtime -->


### PR DESCRIPTION
There's currently an unexplained issue which results in connection
failures like below:

```
com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: zipkin-db-cassandra-1.zipkin-db-cassandra.zipkin.svc.cluster.local/10.200.63.6:9042 (com.datastax.driver.core.exceptions.ConnectionException: [zipkin-db-cassandra-1.zipkin-db-cassandra.zipkin.svc.cluster.local/10.200.63.6:9042] Write attempt on defunct connection))
    at com.datastax.driver.core.RequestHandler.reportNoMoreHosts(RequestHandler.java:232) ~[cassandra-driver-core-3.5.0-shaded.jar!/:?]
    ... 23 more
```

This was observed by @llinder using zipkin's self-tracing. This
disabled outbound propagation by default.