### PR TITLE
Configures Failsafe plugin so ITs run with build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,10 @@ jobs:
           name: Collect test reports
           when: always
           command: |
-            mkdir -p /tmp/test-reports/junit/
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} /tmp/test-reports/junit/ \;
+            mkdir -p /tmp/test-reports/unit-tests/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} /tmp/test-reports/unit-tests/ \;
+            mkdir -p /tmp/test-reports/integration-tests/
+            find . -type f -regex ".*/target/failsafe-reports/TEST.*xml" -exec cp {} /tmp/test-reports/integration-tests/ \;
 
       - store_test_results:
           path: /tmp/test-reports/

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,19 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.22.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Ensures checksums are added to published jars -->
       <plugin>
         <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
Integration tests were not run with the build previously due to missing failsafe plugin configuration.