### PR TITLE
Refactors to latest goodness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:10-jdk
     steps:
 
       - checkout
@@ -54,7 +54,7 @@ jobs:
 
   publish_snapshot:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:10-jdk
     steps:
       - checkout
       - restore_cache:
@@ -69,7 +69,7 @@ jobs:
 
   publish_stable:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:10-jdk
     steps:
       - checkout
       - restore_cache:
@@ -84,7 +84,7 @@ jobs:
 
   trigger_publish:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:10-jdk
     steps:
       - checkout
       - restore_cache:

--- a/cassandra-driver/src/main/java/brave/cassandra/driver/CassandraClientParser.java
+++ b/cassandra-driver/src/main/java/brave/cassandra/driver/CassandraClientParser.java
@@ -55,14 +55,6 @@ public class CassandraClientParser {
   }
 
   /** Override to parse data from the result set into the span modeling it. */
-  public void response(ResultSet resultSet, SpanCustomizer customizer) {}
-
-  /**
-   * Override to change what data from an error are parsed into the span modeling it. Defaults to
-   * the throwable's message, or the simple name of the throwable's type.
-   */
-  public void error(Throwable throwable, SpanCustomizer customizer) {
-    String message = throwable.getMessage();
-    customizer.tag("error", message != null ? message : throwable.getClass().getSimpleName());
+  public void response(ResultSet resultSet, SpanCustomizer customizer) {
   }
 }

--- a/cassandra-driver/src/main/java/brave/cassandra/driver/CassandraClientTracing.java
+++ b/cassandra-driver/src/main/java/brave/cassandra/driver/CassandraClientTracing.java
@@ -15,25 +15,91 @@ package brave.cassandra.driver;
 
 import brave.Tracing;
 import brave.internal.Nullable;
-import com.google.auto.value.AutoValue;
 
-@AutoValue
-public abstract class CassandraClientTracing {
+public final class CassandraClientTracing {
   public static CassandraClientTracing create(Tracing tracing) {
     return newBuilder(tracing).build();
   }
 
   public static Builder newBuilder(Tracing tracing) {
-    return new AutoValue_CassandraClientTracing.Builder()
-        .tracing(tracing)
-        .parser(new CassandraClientParser())
-        .sampler(CassandraClientSampler.TRACE_ID)
-        .propagationEnabled(false);
+    if (tracing == null) throw new NullPointerException("tracing == null");
+    return new Builder(tracing);
   }
 
-  public abstract Tracing tracing();
+  public static final class Builder {
+    final Tracing tracing;
+    CassandraClientParser parser = new CassandraClientParser();
+    CassandraClientSampler sampler = CassandraClientSampler.TRACE_ID;
+    boolean propagationEnabled = false;
+    String remoteServiceName;
 
-  public abstract CassandraClientParser parser();
+    Builder(Tracing tracing) {
+      this.tracing = tracing;
+    }
+
+    Builder(CassandraClientTracing source) {
+      this.tracing = source.tracing;
+      this.parser = source.parser;
+      this.sampler = source.sampler;
+      this.propagationEnabled = source.propagationEnabled;
+      this.remoteServiceName = source.remoteServiceName;
+    }
+
+    /** @see CassandraClientTracing#parser() */
+    public Builder parser(CassandraClientParser parser) {
+      if (parser == null) throw new NullPointerException("parser == null");
+      this.parser = parser;
+      return this;
+    }
+
+    /** @see CassandraClientTracing#sampler() */
+    public Builder sampler(CassandraClientSampler sampler) {
+      if (sampler == null) throw new NullPointerException("sampler == null");
+      this.sampler = sampler;
+      return this;
+    }
+
+    /** @see CassandraClientTracing#propagationEnabled() */
+    public Builder propagationEnabled(boolean propagationEnabled) {
+      this.propagationEnabled = propagationEnabled;
+      return this;
+    }
+
+    public Builder remoteServiceName(@Nullable String remoteServiceName) {
+      this.remoteServiceName = remoteServiceName;
+      return this;
+    }
+
+    public CassandraClientTracing build() {
+      return new CassandraClientTracing(this);
+    }
+  }
+
+  final Tracing tracing;
+  final CassandraClientParser parser;
+  final CassandraClientSampler sampler;
+  final boolean propagationEnabled;
+  @Nullable final String remoteServiceName;
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  CassandraClientTracing(Builder builder) {
+    this.tracing = builder.tracing;
+    this.parser = builder.parser;
+    this.sampler = builder.sampler;
+    this.propagationEnabled = builder.propagationEnabled;
+    this.remoteServiceName = builder.remoteServiceName;
+  }
+
+  public Tracing tracing() {
+    return tracing;
+  }
+
+  public CassandraClientParser parser() {
+    return parser;
+  }
 
   /**
    * Used by cassandra clients to indicate the name of the destination service. Defaults to the
@@ -50,8 +116,9 @@ public abstract class CassandraClientTracing {
    *
    * @see brave.Span#remoteEndpoint(zipkin2.Endpoint)
    */
-  @Nullable
-  public abstract String remoteServiceName();
+  @Nullable public String remoteServiceName() {
+    return remoteServiceName;
+  }
 
   /**
    * Scopes this component for a client of the indicated server.
@@ -69,36 +136,15 @@ public abstract class CassandraClientTracing {
    * <p>Warning: sometimes this can cause connection failures. As such, consider this feature
    * experimental.
    */
-  public abstract boolean propagationEnabled();
+  public boolean propagationEnabled() {
+    return propagationEnabled;
+  }
 
   /**
    * Returns an overriding sampling decision for a new trace. Defaults to ignore the request and use
    * the {@link CassandraClientSampler#TRACE_ID trace ID instead}.
    */
-  public abstract CassandraClientSampler sampler();
-
-  public abstract Builder toBuilder();
-
-  @AutoValue.Builder
-  public abstract static class Builder {
-    /** @see CassandraClientTracing#tracing() */
-    public abstract Builder tracing(Tracing tracing);
-
-    /** @see CassandraClientTracing#parser() */
-    public abstract Builder parser(CassandraClientParser parser);
-
-    /** @see CassandraClientTracing#sampler() */
-    public abstract Builder sampler(CassandraClientSampler sampler);
-
-    /** @see CassandraClientTracing#propagationEnabled() */
-    public abstract Builder propagationEnabled(boolean propagationEnabled);
-
-    public abstract CassandraClientTracing build();
-
-    abstract Builder remoteServiceName(@Nullable String remoteServiceName);
-
-    Builder() {}
+  public CassandraClientSampler sampler() {
+    return sampler;
   }
-
-  CassandraClientTracing() {}
 }

--- a/cassandra-tests/src/main/java/cassandra/CassandraRule.java
+++ b/cassandra-tests/src/main/java/cassandra/CassandraRule.java
@@ -98,7 +98,7 @@ public class CassandraRule extends ExternalResource {
   }
 
   @Override
-  protected void before() throws Throwable {
+  protected void before() {
     if (server != null) return;
 
     DatabaseDescriptor.daemonInitialization();

--- a/cassandra/src/main/java/brave/cassandra/Tracing.java
+++ b/cassandra/src/main/java/brave/cassandra/Tracing.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.cassandra.tracing.TraceState;
 import org.apache.cassandra.utils.FBUtilities;
-import zipkin2.Endpoint;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
@@ -118,7 +117,7 @@ public class Tracing extends org.apache.cassandra.tracing.Tracing {
     parseRequest(state, request, parameters, span);
     // observed parameter keys include page_size, consistency_level, serial_consistency_level, query
 
-    span.remoteEndpoint(Endpoint.newBuilder().ip(client).build());
+    span.remoteIpAndPort(client.getHostAddress(), 0);
     span.start();
     return state;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <main.signature.artifact>java17</main.signature.artifact>
 
     <main.basedir>${project.basedir}</main.basedir>
-    <brave.version>5.1.5</brave.version>
+    <brave.version>5.2.0</brave.version>
 
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
     <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
@@ -106,7 +106,7 @@
       <dependency>
         <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-all</artifactId>
-        <version>3.11.2</version>
+        <version>3.11.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -131,7 +131,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.10.0</version>
+        <version>3.11.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -140,14 +140,6 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
-    </dependency>
-
-    <!-- don't worry. auto-* are source retention, not runtime -->
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <version>1.5.4</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -179,33 +171,20 @@
       <plugin>
         <inherited>true</inherited>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <configuration>
           <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
           <source>1.8</source>
           <target>1.8</target>
-          <compilerId>javac-with-errorprone</compilerId>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <showWarnings>true</showWarnings>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.4</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>
-        <version>2.5.4</version>
+        <version>2.5.5</version>
         <executions>
           <execution>
             <goals>
@@ -321,7 +300,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,10)</version>
+                  <version>[1.8,11)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -352,6 +331,87 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>error-prone-1.8</id>
+      <activation>
+        <jdk>1.8</jdk>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- only use errorprone on main source tree -->
+                <id>default-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <compilerId>javac-with-errorprone</compilerId>
+                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                  <compilerArgs>
+                    <arg>${errorprone.args}</arg>
+                  </compilerArgs>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                <version>2.8.4</version>
+              </dependency>
+              <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>2.3.1</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>error-prone-9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- only use errorprone on main source tree -->
+                <id>default-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                  <compilerArgs>
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>-Xplugin:ErrorProne ${errorprone.args}</arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                    <processorPath>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>2.3.1</version>
+                    </processorPath>
+                  </annotationProcessorPaths>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
     <main.basedir>${project.basedir}</main.basedir>
     <brave.version>5.2.0</brave.version>
 
+    <!-- override to set exclusions per-project -->
+    <errorprone.args/>
+
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
     <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
   </properties>


### PR DESCRIPTION
This removes the cassandra-specific error parser as it is obviated by
the standard one. It also removes auto-value, which complicated build
configuration. Then, it moves to the new apis for recording IP and port
data. Finally, it updates all the versions, most notably the build to
work with JDK 10.