### PR TITLE
Moves build to JDK 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     }
 
     tools {
-        jdk 'JDK 1.8 (latest)'
+        jdk 'JDK 11 (latest)'
     }
 
     options {

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.3.2</errorprone.version>
+    <errorprone.version>2.3.3</errorprone.version>
 
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
@@ -331,7 +331,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,12)</version>
+                  <version>[11,12)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -403,52 +403,9 @@
 
   <profiles>
     <profile>
-      <id>error-prone-1.8</id>
+      <id>error-prone-11+</id>
       <activation>
-        <jdk>1.8</jdk>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <!-- only use errorprone on main source tree -->
-                <id>default-compile</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>compile</goal>
-                </goals>
-                <configuration>
-                  <compilerId>javac-with-errorprone</compilerId>
-                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                  <compilerArgs>
-                    <arg>${errorprone.args}</arg>
-                  </compilerArgs>
-                </configuration>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8.5</version>
-              </dependency>
-              <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>${errorprone.version}</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>error-prone-9+</id>
-      <activation>
-        <jdk>[9,)</jdk>
+        <jdk>[11,)</jdk>
         <activeByDefault>false</activeByDefault>
       </activation>
       <build>


### PR DESCRIPTION
This works around a problem in running the error-prone plugin under JDK 1.8. We don't need to support building with JDK 1.8 in this project.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:testCompile (default-testCompile) on project brave-instrumentation-cassandra-driver: Fatal error compiling: Error while executing the compiler. InvocationTargetException: ANNOTATION_PROCESSOR_MODULE_PATH -> [Help 1]
```