### PR TITLE
Fixes integration test setup and propagation bug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
 
     post {
         always {
-            junit '**/target/surefire-reports/*.xml'
+            junit '**/target/surefire-reports/*.xml **/target/failsafe-reports/*.xml'
             deleteDir()
         }
 

--- a/cassandra/src/main/java/brave/cassandra/Tracing.java
+++ b/cassandra/src/main/java/brave/cassandra/Tracing.java
@@ -33,6 +33,7 @@ import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import static brave.Span.Kind.SERVER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This creates Zipkin server spans for incoming cassandra requests. Spans are created when there's
@@ -96,9 +97,9 @@ public class Tracing extends org.apache.cassandra.tracing.Tracing {
 
   /** This extracts the RPC span encoded in the custom payload, or starts a new trace */
   Span spanFromPayload(Tracer tracer, @Nullable Map<String, ByteBuffer> payload) {
-    ByteBuffer b3 = payload.get("b3");
+    ByteBuffer b3 = payload != null ? payload.get("b3") : null;
     if (b3 == null) return tracer.nextSpan();
-    TraceContextOrSamplingFlags extracted = B3SingleFormat.parseB3SingleFormat(b3.asCharBuffer());
+    TraceContextOrSamplingFlags extracted = B3SingleFormat.parseB3SingleFormat(UTF_8.decode(b3));
     if (extracted == null) return tracer.nextSpan();
     return tracer.nextSpan(extracted);
   }

--- a/cassandra/src/test/java/brave/cassandra/ITTracing.java
+++ b/cassandra/src/test/java/brave/cassandra/ITTracing.java
@@ -17,6 +17,7 @@
 package brave.cassandra;
 
 import brave.ScopedSpan;
+import brave.cassandra.driver.CassandraClientTracing;
 import brave.cassandra.driver.TracingSession;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
@@ -153,11 +154,13 @@ public class ITTracing {
   }
 
   void executeTraced(Function<Session, Statement> statement) {
+    CassandraClientTracing withPropagation = CassandraClientTracing.newBuilder(tracing)
+        .propagationEnabled(true).build();
     try (Cluster cluster =
             Cluster.builder()
                 .addContactPointsWithPorts(Collections.singleton(cassandra.contactPoint()))
                 .build();
-        Session session = TracingSession.create(tracing, cluster.connect())) {
+        Session session = TracingSession.create(withPropagation, cluster.connect())) {
       session.execute(statement.apply(session));
     }
   }

--- a/cassandra/src/test/java/brave/cassandra/TracingTest.java
+++ b/cassandra/src/test/java/brave/cassandra/TracingTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brave.cassandra;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracingTest {
+  List<Span> spans = new ArrayList<>();
+  brave.Tracing tracing = brave.Tracing.newBuilder()
+      .spanReporter(spans::add)
+      .build();
+  Tracing cassandraTracing = new Tracing(tracing);
+
+  @After public void tearDown() {
+    tracing.close();
+  }
+
+  @Test public void spanFromPayload_startsTraceOnNullPayload() {
+    assertThat(cassandraTracing.spanFromPayload(tracing.tracer(), null))
+        .isNotNull();
+  }
+
+  @Test public void spanFromPayload_startsTraceOnAbsentB3SingleEntry() {
+    assertThat(cassandraTracing.spanFromPayload(tracing.tracer(), Collections.emptyMap()))
+        .isNotNull();
+  }
+
+  @Test public void spanFromPayload_resumesTraceOnB3SingleEntry() {
+    assertThat(cassandraTracing.spanFromPayload(tracing.tracer(), Collections.singletonMap("b3",
+        ByteBuffer.wrap(new byte[] {'0'}))))
+        .extracting(b -> b.isNoop())
+        .isEqualTo(Boolean.TRUE);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
     <main.basedir>${project.basedir}</main.basedir>
     <brave.version>5.6.3</brave.version>
 
+    <log4j.version>2.11.2</log4j.version>
+
     <!-- override to set exclusions per-project -->
     <errorprone.args />
     <errorprone.version>2.3.3</errorprone.version>
@@ -145,6 +147,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!-- Override until Cassandra 4.0 per CASSANDRA-9608 -->
+      <dependency>
+        <groupId>com.github.jbellis</groupId>
+        <artifactId>jamm</artifactId>
+        <version>0.3.3</version>
+      </dependency>
       <dependency>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-core</artifactId>
@@ -159,6 +167,22 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.12.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+        <version>${log4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -179,8 +203,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
 
   <build>
     <pluginManagement>
@@ -251,6 +279,20 @@
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
There was a propagation bug that resulted in cassandra server not
continuing inbound traces. This was hidden by incorrect integration
test setup.

Fixes #11