### PR TITLE
Restores CONTRIBUTING file and cleans up drift in READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Apache Zipkin (incubating)
+
+If you would like to contribute code, fork this GitHub repository and
+send a pull request on a branch other than `master`.
+
+When submitting code, please apply [Square Code Style](https://github.com/square/java-code-styles).
+* If the settings import correctly, CodeStyle/Java will be named Square and use 2 space tab and indent, with 4 space continuation indent.
+
+## License
+
+By contributing your code, you agree to license your contribution under
+the terms of the [APLv2](LICENSE).
+
+All files are released with the Apache 2.0 license.
+
+If you are adding a new file it should have a header like below. This
+can be automatically added by running `./mvnw com.mycila:license-maven-plugin:format`.
+
+```
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ ```
+
+## Contributor Agreement
+
+Non-trivial change requires an Individual Contributor License Agreement
+(ICLA). The ICLA applies to all Apache Software Foundation projects, and
+is a one-time effort. If you have not yet filled an ICLA, download the [template](https://www.apache.org/licenses/icla.pdf).
+After filling the form with your information print, sign, scan, and send
+it in an email attachment to secretary@apache.org. You will get a
+confirmation and end up on a [list we can check](http://people.apache.org/unlistedclas.html).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ Artifacts are under the maven group id `org.apache.zipkin.brave.cassandra`
 ### Source Releases
 Source Releases are uploaded to [Apache](https://dist.apache.org/repos/dist/release/incubator/zipkin/brave-cassandra)
 ### Binary Releases
-Releases are uploaded to [Apache](https://repository.apache.org/service/local/staging/deploy/maven2) and synchronized to [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.zipkin.brave.cassandra%22)
+Binary Releases are uploaded to [Apache](https://repository.apache.org/service/local/staging/deploy/maven2) and synchronized to [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.zipkin.brave.cassandra%22)
 ### Binary Snapshots
-Snapshots are uploaded to [Apache](https://repository.apache.org/content/repositories/snapshots/) after commits to master.
+Binary Snapshots are uploaded to [Apache](https://repository.apache.org/content/repositories/snapshots/) after commits to master.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin)
-[![Build Status](https://circleci.com/gh/openzipkin/brave-cassandra.svg?style=svg)](https://circleci.com/gh/openzipkin/brave-cassandra)
-[![Download](https://api.bintray.com/packages/openzipkin/maven/brave-cassandra/images/download.svg)](https://bintray.com/openzipkin/maven/brave-cassandra/_latestVersion)
+[![Build Status](https://img.shields.io/jenkins/s/https/builds.apache.org/job/incubator-zipkin-brave-cassandra.svg)](https://builds.apache.org/blue/organizations/jenkins/incubator-zipkin-brave-cassandra)
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.zipkin.brave.cassandra/brave-instrumentation-cassandra.svg)](https://search.maven.org/search?q=g:org.apache.zipkin.brave.cassandra%20AND%20a:brave-instrumentation-cassandra)
 
 # brave-cassandra
 This contains tracing instrumentation for [Cassandra](https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/tracing/Tracing.java) and the [DataStax Java Driver](https://github.com/datastax/java-driver).
@@ -15,8 +15,10 @@ server integration is in place, cassandra will contribute data to these
 RPC spans.
 
 ## Artifacts
-Artifacts are under the maven group id `io.zipkin.brave.cassandra`
-### Library Releases
-Releases are uploaded to [Bintray](https://bintray.com/openzipkin/maven/brave-cassandra) and synchronized to [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.zipkin.brave.cassandra%22)
-### Library Snapshots
-Snapshots are uploaded to [JFrog](http://oss.jfrog.org/artifactory/oss-snapshot-local) after commits to master.
+Artifacts are under the maven group id `org.apache.zipkin.brave.cassandra`
+### Source Releases
+Source Releases are uploaded to [Apache](https://dist.apache.org/repos/dist/release/incubator/zipkin/brave-cassandra)
+### Binary Releases
+Releases are uploaded to [Apache](https://repository.apache.org/service/local/staging/deploy/maven2) and synchronized to [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.zipkin.brave.cassandra%22)
+### Binary Snapshots
+Snapshots are uploaded to [Apache](https://repository.apache.org/content/repositories/snapshots/) after commits to master.

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -52,10 +52,7 @@ preparedStatement.enableTracing();
 
 // By default, B3 style is used, so instrumented clients do something like this
 Map<String, ByteBuffer> payload = new LinkedHashMap<>();
-payload.set("X-B3-TraceId", byteBuffer("463ac35c9f6413ad"));
-payload.set("X-B3-ParentSpanId", byteBuffer("463ac35c9f6413ad"));
-payload.set("X-B3-SpanId", byteBuffer("72485a3953bb6124"));
-payload.set("X-B3-Sampled", byteBuffer("1"));
+payload.set("b3", byteBuffer("463ac35c9f6413ad-72485a3953bb6124-1-463ac35c9f6413ad"));
 preparedStatement.setOutgoingPayload(payload);
 ```
 


### PR DESCRIPTION
This restores the CONTRIBUTING file, correcting the license text and
adding a section on getting an ICLA. This also fixes some drift in the
README files.