### PR TITLE
Simplifies travis configuration and moves auth to where it is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-arch: arm64 # Can't use arm64-graviton2 as it cycles on boot as of 2020-11-02
+arch: arm64 # Not arm64-graviton2 as it cycles on boot for a long time before running [2020-11-02]
 virt: lxd   # LXD containers where possible as they boot much faster than full VMs
 os: linux   # required for arch different than amd64
 dist: focal # newest available distribution
@@ -97,7 +97,7 @@ notifications:
 
 # Secure variables needed for release and publication
 #
-# When Travis, add to https://travis-ci.org/github/openzipkin/${REPO}/settings
+# When Travis, add to https://travis-ci.com/github/openzipkin/${REPO}/settings
 #
 # GH_TOKEN=XXX-https://github.com/settings/tokens-XXX
 #   - makes release commits and tags, also writes to GHCR if Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-arch: arm64-graviton2 # in AWS over Graviton2 CPU
+arch: amd64           # Use default architecture
 virt: lxd             # LXD containers where possible as they boot much faster than full VMs
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
-# We use LXD containers where possible as they boot much faster than full VMs
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-arch: arm64           # LXD container based build for OSS only
+arch: arm64-graviton2 # in AWS over Graviton2 CPU
+virt: lxd             # LXD containers where possible as they boot much faster than full VMs
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ dist: focal           # newest available distribution
 git:
   depth: false
 
+# Re-use JDK 11 from focal release instead of delaying build with installation
 language: java
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,33 +17,8 @@ cache:
   directories:
     - $HOME/.m2
 
-# Re-use JDK 11 from focal release instead of delaying build with installation
-before_install:
-  # Set prefix of commands used in release
-  #  * -Prelease ensures the core jar ends up JRE 1.6 compatible
-  - mvn_release="./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests"
-
-  # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
-  # controlled by branch (typically only master). Check to see if a well-known env is available
-  # before attempting to log in.
-  - |
-    if [[ -n "$SONATYPE_USER" ]]; then
-      # allocate commits to CI, not the owner of the deploy key
-      git config user.name "zipkinci"
-      git config user.email "zipkinci+zipkin-dev@googlegroups.com"
-
-      # setup https authentication credentials, used by ./mvnw release:prepare
-      git config credential.helper "store --file=.git/credentials"
-      echo "https://$GH_TOKEN:@github.com" > .git/credentials || travis_terminate 1
-
-      # ensure GPG commands work non-interactively
-      export GPG_TTY=$(tty)
-      # import signing key used for jar files
-      echo ${GPG_SIGNING_KEY} | base64 --decode | gpg --batch --passphrase ${GPG_PASSPHRASE} --import || travis_terminate 1
-    fi
-
 # use a go-offline that properly works with multi-module builds
-install: ${mvn_release} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+install: ./mvnw --batch-mode de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 
 # Add deployment jobs. Note: "branch = master" for PRs, this is the base branch name.
 #
@@ -69,14 +44,31 @@ jobs:
           type = push AND env(SONATYPE_USER) IS present
       name: "Deploy a SNAPSHOT or release to Sonatype"
       # travis_wait ensures upload delays don't kill the deployment
-      script: travis_wait ${mvn_release} deploy
-    # Deploy a release when a release trigger and secure variables are available
+      script:
+        # Setup GPG to sign the artifacts uploaded to Sonatype
+        - |
+          # ensure GPG commands work non-interactively
+          export GPG_TTY=$(tty)
+          # import signing key used for jar files
+          echo ${GPG_SIGNING_KEY} | base64 --decode | gpg --batch --passphrase ${GPG_PASSPHRASE} --import || travis_terminate 1
+        # Perform the deployment: travis_wait ensures upload delays don't kill the deployment
+        - travis_wait ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+    # Create a release version when a release trigger and credentials needed for git are available
     - stage: create release
       if: |
           tag =~ ^release-[0-9]+\.[0-9]+\.[0-9]+ AND \
-          type = push AND env(SONATYPE_USER) IS present
-      name: "Create release"
+          type = push AND env(GH_TOKEN) IS present
+      name: "Create release version"
       script:
+        # Configure git as release implies pushing commits and tags
+        - |
+          # Allocate commits to CI, not the owner of the deploy key
+          git config user.name "zipkinci"
+          git config user.email "zipkinci+zipkin-dev@googlegroups.com"
+
+          # Setup https authentication credentials, used by ./mvnw release:prepare
+          git config credential.helper "store --file=.git/credentials"
+          echo "https://$GH_TOKEN:@github.com" > .git/credentials || travis_terminate 1
         # Checkout master, as we release from master, not a tag ref
         - git checkout -B master || travis_terminate 1
         # Ensure no one pushed commits since this release tag as it would fail later commands
@@ -92,9 +84,8 @@ jobs:
         - |
           release_version=$(echo "${TRAVIS_TAG}" | sed 's/^release-//') || travis_terminate 1
           git push origin :"${TRAVIS_TAG}"
-        # Prepare and push release commits. '[skip ci]' ensures Travis doesn't build these commits.
-        # These commits push immediately as time uploading deployments adds git conflict risk.
-        - ${mvn_release} -DreleaseVersion=${release_version} -Darguments=-DskipTests release:prepare
+        # Prepare and push release commits and the version tag (N.N.N), which triggers deployment.
+        - ./mvnw --batch-mode -nsu -DreleaseVersion=${release_version} -Darguments=-DskipTests release:prepare
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-arch: arm64-graviton2 # Use AWS Graviton2
-group: edge           # Required with arm64-graviton2 per https://blog.travis-ci.com/2020-09-11-arm-on-aws
-virt: lxd             # LXD containers where possible as they boot much faster than full VMs
-os: linux             # required for arch different than amd64
-dist: focal           # newest available distribution
+arch: arm64 # Can't use arm64-graviton2 as it cycles on boot as of 2020-11-02
+virt: lxd   # LXD containers where possible as they boot much faster than full VMs
+os: linux   # required for arch different than amd64
+dist: focal # newest available distribution
 
 # license-maven-plugin needs the full history to generate copyright year range. Ex. 2013-2020
 # Don't do a shallow clone, as it interferes with this.

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ jobs:
               tag =~ ^[0-9]+\.[0-9]+\.[0-9]+ ) AND \
           type = push AND env(SONATYPE_USER) IS present
       name: "Deploy a SNAPSHOT or release to Sonatype"
-      # travis_wait ensures upload delays don't kill the deployment
       script:
         # Setup GPG to sign the artifacts uploaded to Sonatype
         - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-arch: amd64           # Use default architecture
+arch: arm64-graviton2 # Use AWS Graviton2
+group: edge           # Required with arm64-graviton2 per https://blog.travis-ci.com/2020-09-11-arm-on-aws
 virt: lxd             # LXD containers where possible as they boot much faster than full VMs
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin)
-[![Build Status](https://circleci.com/gh/openzipkin/brave-cassandra.svg?style=svg)](https://circleci.com/gh/openzipkin/brave-cassandra)
+[![Build Status](https://travis-ci.com/openzipkin/brave-cassandra.svg?branch=master)](https://travis-ci.com/openzipkin/brave-cassandra)
 [![Maven Central](https://img.shields.io/maven-central/v/io.zipkin.brave.cassandra/brave-instrumentation-cassandra.svg)](https://search.maven.org/search?q=g:io.brave.cassandra%20AND%20a:brave-instrumentation-cassandra)
 
 # brave-cassandra

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ This repo uses semantic versions. Please keep this in mind when choosing version
 ## Credentials
 
 The release process uses various credentials. If you notice something failing due to unauthorized,
-look at the notes in [.travis.yml] and check the [project settings](https://travis-ci.org/github/openzipkin/zipkin/settings)
+look at the notes in [.travis.yml] and check the [project settings](https://travis-ci.com/github/openzipkin/zipkin/settings)
 
 ### Troubleshooting invalid credentials
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -75,7 +75,6 @@ release_version=xx-version-to-release-xx
 
 # Once this works, deploy to Sonatype, which synchronizes to maven central
 git checkout ${release_version}
-# -Prelease ensures the core jar ends up JRE 1.6 compatible
 ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 
 # Once all the above worked, clean up the release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,16 +69,14 @@ export SONATYPE_USER=your_sonatype_account
 export SONATYPE_PASSWORD=your_sonatype_password
 release_version=xx-version-to-release-xx
 
-# -Prelease ensures the core jar ends up JRE 1.6 compatible
-mvn_release="./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu"
-
 # Prepare and push release commits. These commits push immediately as time uploading deployments
 # adds git conflict risk.
-${mvn_release} -DreleaseVersion=${release_version} -Darguments=-DskipTests release:prepare
+./mvnw --batch-mode -nsu -DreleaseVersion=${release_version} -Darguments=-DskipTests release:prepare
 
 # Once this works, deploy to Sonatype, which synchronizes to maven central
 git checkout ${release_version}
-${mvn_release} -DskipTests deploy
+# -Prelease ensures the core jar ends up JRE 1.6 compatible
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 
 # Once all the above worked, clean up the release
 ./mvnw release:clean

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,7 @@ is a good way to validate that your unencrypted credentials are authorized.
 
 Here's an example of a snapshot deploy with specified credentials.
 ```bash
-$ export GPG_TTY=$(tty) && GPG_PASSPHRASE=whackamole SONATYPE_USER=adrianmole SONATYPE_PASSWORD=ed6f20bde9123bbb2312b221 TRAVIS_PULL_REQUEST=false TRAVIS_TAG= TRAVIS_BRANCH=master travis/publish.sh
+$ export GPG_TTY=$(tty) && GPG_PASSPHRASE=whackamole SONATYPE_USER=adrianmole SONATYPE_PASSWORD=ed6f20bde9123bbb2312b221 ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 ```
 
 ## First release of the year


### PR DESCRIPTION
Before, we used heuristics in multiple places to decode credentials.

Now that the build is organized better, we can use credentials only
where needed. This helps instruct what access is needed for what step.