### PR TITLE
Stops build early if the change only effects documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,13 @@ jobs:
       # conditions here don't match the release conditions.
       before_install:
         - |
-          if [ -n "${TRAVIS_COMMIT_RANGE}" ] && git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- | grep -qv '\.md$'; then
-            echo "Stopping job as changes only affect documentation (ex. README.md)"
-            travis_terminate 0
+          if [ -n "${TRAVIS_COMMIT_RANGE}" ]; then
+            CHANGES=$(git diff --name-only "${TRAVIS_COMMIT_RANGE}" --) || travis_terminate 1
+            echo ${CHANGES}
+            if echo ${CHANGES} | grep -qv '\.md$'; then
+              echo "Stopping job as changes only affect documentation (ex. README.md)"
+              travis_terminate 0
+            fi
           fi
       script: ./mvnw verify -nsu || travis_terminate 1
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,13 +57,9 @@ jobs:
       # conditions here don't match the release conditions.
       before_install:
         - |
-          if [ -n "${TRAVIS_COMMIT_RANGE}" ]; then
-            CHANGES=$(git diff --name-only "${TRAVIS_COMMIT_RANGE}" --) || travis_terminate 1
-            echo ${CHANGES}
-            if echo ${CHANGES} | grep -qv '\.md$'; then
-              echo "Stopping job as changes only affect documentation (ex. README.md)"
-              travis_terminate 0
-            fi
+          if [ -n "${TRAVIS_COMMIT_RANGE}" ] && ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- | grep -qv '\.md$'; then
+            echo "Stopping job as changes only affect documentation (ex. README.md)"
+            travis_terminate 0
           fi
       script: ./mvnw verify -nsu || travis_terminate 1
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,17 @@ cache:
 # use a go-offline that properly works with multi-module builds
 install: ./mvnw --batch-mode de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 
+_deploy_script: &deploy_script
+  script:
+    # Setup GPG to sign the artifacts uploaded to Sonatype
+    - |
+      # ensure GPG commands work non-interactively
+      export GPG_TTY=$(tty)
+      # import signing key used for jar files
+      echo ${GPG_SIGNING_KEY} | base64 --decode | gpg --batch --passphrase ${GPG_PASSPHRASE} --import || travis_terminate 1
+    # Perform the deployment: travis_wait ensures upload delays don't kill the deployment
+    - travis_wait ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+
 # Add deployment jobs. Note: "branch = master" for PRs, this is the base branch name.
 #
 # See https://docs.travis-ci.com/user/conditional-builds-stages-jobs#conditional-stages
@@ -31,28 +42,40 @@ jobs:
       # We run tests on non-tagged pushes to master that aren't commit made by the release plugin
       # We also run tests on pull requests targeted at the master branch.
       if: |
-          branch = master AND tag IS blank AND \
-          commit_message !~ /maven-release-plugin/ AND \
+          branch = master AND tag IS blank AND commit_message !~ maven-release-plugin AND \
           type IN (push, pull_request)
       name: "Run unit and integration tests"
+      # Prevent test and SNAPSHOT deploy of a documentation-only change.
+      #
+      # if: conditions are preferred as they obviate job creation. However, they can only use
+      # pre-defined env variables or globals that can be evaluated statically. The other way to skip
+      # is to exit early. We do that here to prevent overhead of running tests and SNAPSHOT deploys
+      # that only include Markdown (documentation) updates. Early terminating here will also prevent
+      # the subsequent deploy SNAPSHOT job.
+      #
+      # Note: This early exit does not prevent a release tag on a doc-only commit because the if:
+      # conditions here don't match the release conditions.
+      before_install:
+        - |
+          if [ -n "${TRAVIS_COMMIT_RANGE}" ] && git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- | grep -qv '\.md$'; then
+            echo "Stopping job as changes only affect documentation (ex. README.md)"
+            travis_terminate 0
+          fi
       script: ./mvnw verify -nsu || travis_terminate 1
     - stage: deploy
       # If we are on master, deploy a SNAPSHOT (unless this is a commit made by the release plugin)
+      if: |
+          branch = master AND tag IS blank AND commit_message !~ maven-release-plugin AND \
+          type = push AND env(SONATYPE_USER) IS present
+      name: "Deploy a SNAPSHOT to Sonatype"
+      <<: *deploy_script
+    - stage: deploy
       # If we are on a version tag, deploy it to Sonatype (automatically releases to Maven Central)
       if: |
-          ( ( branch = master AND tag IS blank AND commit_message !~ /maven-release-plugin/ ) OR
-              tag =~ ^[0-9]+\.[0-9]+\.[0-9]+ ) AND \
+          tag =~ ^[0-9]+\.[0-9]+\.[0-9]+ AND \
           type = push AND env(SONATYPE_USER) IS present
-      name: "Deploy a SNAPSHOT or release to Sonatype"
-      script:
-        # Setup GPG to sign the artifacts uploaded to Sonatype
-        - |
-          # ensure GPG commands work non-interactively
-          export GPG_TTY=$(tty)
-          # import signing key used for jar files
-          echo ${GPG_SIGNING_KEY} | base64 --decode | gpg --batch --passphrase ${GPG_PASSPHRASE} --import || travis_terminate 1
-        # Perform the deployment: travis_wait ensures upload delays don't kill the deployment
-        - travis_wait ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+      name: "Deploy a release to Sonatype"
+      <<: *deploy_script
     # Create a release version when a release trigger and credentials needed for git are available
     - stage: create release
       if: |


### PR DESCRIPTION
Prevent test and SNAPSHOT deploy of a documentation-only change.

if: conditions are preferred as they obviate job creation. However, they can only use
pre-defined env variables or globals that can be evaluated statically. The other way to skip
is to exit early. We do that here to prevent overhead of running tests and SNAPSHOT deploys
that only include Markdown (documentation) updates. Early terminating here will also prevent
the subsequent deploy SNAPSHOT job.

Note: This early exit does not prevent a release tag on a doc-only commit because the if:
conditions here don't match the release conditions.