### PR TITLE
Changes server-side tracing from Cassandra 3.x to 4.x

### DIFF
--- a/cassandra-tests/src/main/java/cassandra/CassandraContainer.java
+++ b/cassandra-tests/src/main/java/cassandra/CassandraContainer.java
@@ -25,7 +25,7 @@ import static org.testcontainers.utility.DockerImageName.parse;
 
 public class CassandraContainer extends GenericContainer<CassandraContainer> {
   public CassandraContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-cassandra:2.23.7"));
+    super(parse("ghcr.io/openzipkin/zipkin-cassandra:2.27.0"));
     waitStrategy = Wait.forHealthcheck();
     addExposedPort(9042);
     withStartupTimeout(Duration.ofMinutes(2));

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
       <dependency>
         <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-all</artifactId>
-        <!-- Matches last zipkin test image (v2.23.7) -->
-        <version>3.11.9</version>
+        <!-- Matches last zipkin test image (v2.27.0) -->
+        <version>4.1.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This is tested on Cassandra 4.1.3 and is not compatible with Cassandra 3.x due to API changes on its Tracer type.

This also adds the local endpoint information to the spans sent to Zipkin.